### PR TITLE
Feature detect constexpr and added constructor

### DIFF
--- a/include/yorel/multi_methods/extern_macros.hpp
+++ b/include/yorel/multi_methods/extern_macros.hpp
@@ -22,6 +22,6 @@
 
 #define MULTI_METHOD(ID, RETURN_TYPE, ARGS...)                          \
   template<typename Sig> struct ID ## _specialization;                  \
-  constexpr ::yorel::multi_methods::multi_method<ID ## _specialization, RETURN_TYPE(ARGS)> ID{}; \
+  YOMM_CONSTEXPR ::yorel::multi_methods::multi_method<ID ## _specialization, RETURN_TYPE(ARGS)> ID; \
   YOREL_MM_TRACE(inline const char* _yomm11_name_(::yorel::multi_methods::multi_method<ID ## _specialization, RETURN_TYPE(__VA_ARGS__)>*) { return #ID; })     \
   extern template class ::yorel::multi_methods::detail::multi_method_implementation<RETURN_TYPE, ARGS>

--- a/include/yorel/multi_methods/macros.hpp
+++ b/include/yorel/multi_methods/macros.hpp
@@ -32,11 +32,17 @@
 #define MM_INIT_MULTI(BASE)                     \
   this->BASE::_init_yomm11_ptr(this)
 
+#ifdef __cpp_constexpr
+#define YOMM_CONSTEXPR constexpr
+#else
+#define YOMM_CONSTEXPR const
+#endif
+
 #undef MULTI_METHOD
 #define MULTI_METHOD(ID, RETURN_TYPE, ...)                          \
   template<typename Sig> struct ID ## _specialization;                  \
   YOREL_MM_TRACE(inline const char* _yomm11_name_(::yorel::multi_methods::multi_method<ID ## _specialization, RETURN_TYPE(__VA_ARGS__)>*) { return #ID; })     \
-  const ::yorel::multi_methods::multi_method<ID ## _specialization, RETURN_TYPE(__VA_ARGS__)> ID
+  YOMM_CONSTEXPR ::yorel::multi_methods::multi_method<ID ## _specialization, RETURN_TYPE(__VA_ARGS__)> ID
 
 #define BEGIN_SPECIALIZATION(ID, RESULT, ...)                       \
   template<>                                                            \

--- a/include/yorel/multi_methods/no_macros.hpp
+++ b/include/yorel/multi_methods/no_macros.hpp
@@ -397,6 +397,10 @@ mm_class::initializer<Class, mm_class::base_list<Bases...>> mm_class::initialize
 template<template<typename Sig> class Method, typename R, typename... P>
 struct multi_method<Method, R(P...)> {
 
+#ifdef __cpp_constexpr
+  constexpr
+#endif
+  multi_method() {}
   R operator ()(typename detail::remove_virtual<P>::type... args) const;
   static R method(typename detail::remove_virtual<P>::type... args);
 


### PR DESCRIPTION
The default constructor is required because of the C++ standard, section 8.5:

```
If a program calls for the default initialization of an object of a const-qualified type T, T shall be a class type with a user-provided default constructor.
```
